### PR TITLE
Include hard-wired-test-name file at visible_filenames

### DIFF
--- a/start_point/manifest.json
+++ b/start_point/manifest.json
@@ -5,7 +5,8 @@
   "visible_filenames": [
     "HikerTest.kt",
     "Hiker.kt",
-    "cyber-dojo.sh"
+    "cyber-dojo.sh",
+    "hard-wired-test-name.txt"
   ],
 
   "image_name": "cyberdojofoundation/kotlin_kotlintest",


### PR DESCRIPTION
There are some warnings at the files "`[X]`" which indicate looking for a text file with a description. However, this text file is invisible at the workspace.

I believe this is due to `manifest.json` missing and indication for it, and for this reason I added it to the file.